### PR TITLE
Added feature comment_count to GET /api/articles/:article_id with tests

### DIFF
--- a/__tests__/endpoints.test.js
+++ b/__tests__/endpoints.test.js
@@ -64,6 +64,15 @@ describe('GET /api/articles/:article_id', () => {
                 })
         })
     })
+    describe.only('feature request, returns number of associated comments of article', () => {
+        test('when called with an existing id response article object has comment_count property (number of associated comments)', () => {
+            return request(app).get('/api/articles/9')
+                .expect(200)
+                .then((res) => {
+                    expect(res.body.article.comment_count).toBe(2);
+                });
+        })
+    })
     describe('Error handling', () => {
         test('when given syntactically correct but non-existent parameter responds with an empty object articles object on res.body', () => {
             return request(app).get('/api/articles/532939827')

--- a/models.js
+++ b/models.js
@@ -22,12 +22,18 @@ exports.retrieveArticles = () => {
 }
 
 exports.retrieveArticleById = (id) => {
-    return db.query('SELECT * FROM articles WHERE article_id = $1;', [id])
+        return db.query(`SELECT * FROM (SELECT articles.author, articles.title, articles.article_id, articles.body, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT(comments.comment_id) AS comment_count FROM articles
+        LEFT JOIN comments
+        ON articles.article_id = comments.article_id
+        GROUP BY articles.article_id) AS articles_comment_count
+WHERE articles_comment_count.article_id = $1;`, [id])
         .then((queryResult) => {
             if (!queryResult.rows[0]) {
                 return {}
+            } else {
+                queryResult.rows[0].comment_count = Number(queryResult.rows[0].comment_count);
+                return queryResult.rows[0];
             }
-            return queryResult.rows[0];
         })
 }
 


### PR DESCRIPTION
1. Added additional functionality of GET /api/articles/:article_id endpoint to include 'comment_count' (number of associated comments) in article response object
2. Built the additional functionality using TDD